### PR TITLE
Fix link for React 'Strict mode'

### DIFF
--- a/docs/other/react-philosophies.md
+++ b/docs/other/react-philosophies.md
@@ -56,7 +56,7 @@ _Настройки `eslint`_
 
 - [Feedback for 'exhaustive-deps' lint rule](https://github.com/facebook/react/issues/14920)
 
-2. Включай [строгий режим](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Strict_mode). На дворе 2022 год, в конце концов.
+2. Включай [строгий режим](https://reactjs.org/docs/strict-mode.html). На дворе 2022 год, в конце концов.
 
 ```js
 ReactDOM.render(


### PR DESCRIPTION
I guess the mention of strict mode in the context of <React.StrictMode> is about React native tool, not about JS "use strict" pragma. I suggest to replace the link to React doc.