### PR TITLE
Fixed images path in contacts block

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,13 +149,13 @@ const config = {
             title: 'Контакты',
             items: [
               {
-                html: '<p class="footer__link"><img src="../../img/github.png" alt="" width="32" height="32"> <a href="https://github.com/harryheman" target="_blank">harryheman</a></p>',
+                html: '<p class="footer__link"><img src="/img/github.png" alt="" width="32" height="32"> <a href="https://github.com/harryheman" target="_blank">harryheman</a></p>',
               },
               {
-                html: '<p class="footer__link"><img src="../../img/telegram.png" alt="" width="32" height="32"> @igoragapov</p>',
+                html: '<p class="footer__link"><img src="/img/telegram.png" alt="" width="32" height="32"> @igoragapov</p>',
               },
               {
-                html: '<p class="footer__link"><img src="../../img/email.png" alt="" width="32" height="32"><a href="mailto:aio350@yahoo.com">aio350@yahoo.com</a></p>',
+                html: '<p class="footer__link"><img src="/img/email.png" alt="" width="32" height="32"><a href="mailto:aio350@yahoo.com">aio350@yahoo.com</a></p>',
               },
               {
                 label: 'Habr',


### PR DESCRIPTION
В конфиге `docusaurus.config.js` пути к изображениям были указаны некорректно: если прейти на страницу отличной от главной (корневой), и обновить её, то изображения в контактах не отображались. Исправил пути к этим изображениям так, чтобы они всегда смотрели в корень.