### PR TITLE
Fixed code in 186 js-question.md

### DIFF
--- a/docs/other/js-questions.md
+++ b/docs/other/js-questions.md
@@ -5245,7 +5245,7 @@ Spread-оператор `...x` позволяет получить параме�
 ```js
 var tip = 100
 
-(function () {
+;(function () {
   console.log("I have $" + husband())
 
   function wife() {


### PR DESCRIPTION
В коде 186 вопроса по JS отсутствовала точка с запятой после объявления переменной на первой строке, что приводило бы к ошибке выполнения данного кода. Исправлено - точка с запятой добавлена.